### PR TITLE
Upgrade to Keycloak 13.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.thomasdarimont.keycloak</groupId>
     <artifactId>keycloak-health-checks</artifactId>
-    <version>13.0.0.1</version>
+    <version>13.0.1.1</version>
 
     <properties>
         <!-- general settings -->
@@ -18,7 +18,7 @@
         <!-- dependency versions -->
         <lombok.version>1.18.4</lombok.version>
 
-        <keycloak.version>13.0.0</keycloak.version>
+        <keycloak.version>13.0.1</keycloak.version>
         <keycloak.versionedArtifactName>keycloak-${keycloak.version}</keycloak.versionedArtifactName>
         <infinispan.version>11.0.9.Final</infinispan.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.thomasdarimont.keycloak</groupId>
     <artifactId>keycloak-health-checks</artifactId>
-    <version>4.8.3.0-SNAPSHOT</version>
+    <version>13.0.0.1</version>
 
     <properties>
         <!-- general settings -->
@@ -18,9 +18,9 @@
         <!-- dependency versions -->
         <lombok.version>1.18.4</lombok.version>
 
-        <keycloak.version>4.8.3.Final</keycloak.version>
+        <keycloak.version>13.0.0</keycloak.version>
         <keycloak.versionedArtifactName>keycloak-${keycloak.version}</keycloak.versionedArtifactName>
-        <infinispan.version>9.3.1.Final</infinispan.version>
+        <infinispan.version>11.0.9.Final</infinispan.version>
     </properties>
 
     <dependencies>
@@ -78,10 +78,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
-
     </build>
 
     <repositories>

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ You are disconnected at the moment. Type 'connect' to connect to the server or '
 [disconnected /] connect
 [standalone@localhost:9990 /] 
 
-[standalone@localhost:9990 /] module add --name=com.github.thomasdarimont.keycloak.extensions.keycloak-health-checks --resources=/home/tom/dev/repos/gh/thomasdarimont/keycloak-dev/keycloak-health-checks/target/keycloak-health-checks-4.8.3.0-SNAPSHOT.jar --dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-services,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,javax.api,javax.ws.rs.api,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations,org.jboss.logging,org.infinispan,org.infinispan.commons
+[standalone@localhost:9990 /] module add --name=com.github.thomasdarimont.keycloak.extensions.keycloak-health-checks --resources=/home/tom/dev/repos/gh/thomasdarimont/keycloak-dev/keycloak-health-checks/target/keycloak-health-checks-13.0.0.0.jar --dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-services,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,javax.api,javax.ws.rs.api,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations,org.jboss.logging,org.infinispan,org.infinispan.commons
 ```
 
 Alternatively, create `$KEYCLOAK_HOME/modules/com/github/thomasdarimont/keycloak/extensions/keycloak-health-checks/main/module.xml` to load extension from the local Maven repo:
@@ -31,7 +31,7 @@ Alternatively, create `$KEYCLOAK_HOME/modules/com/github/thomasdarimont/keycloak
 <module xmlns="urn:jboss:module:1.1" name="com.github.thomasdarimont.keycloak.extensions.keycloak-health-checks">
 
     <resources>
-        <artifact name="com.github.thomasdarimont.keycloak:keycloak-health-checks:4.8.3.0-SNAPSHOT"/>
+        <artifact name="com.github.thomasdarimont.keycloak:keycloak-health-checks:13.0.0.0"/>
     </resources>
 
     <dependencies>

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A collection of health-checks for Keycloak subsystems.
 
 ## Requirements
 
-* KeyCloak 4.8.3.Final
+* KeyCloak 13.0.0
 
 ## Build
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A collection of health-checks for Keycloak subsystems.
 
 ## Requirements
 
-* KeyCloak 13.0.0
+* KeyCloak 13.0.1
 
 ## Build
 
@@ -21,7 +21,7 @@ You are disconnected at the moment. Type 'connect' to connect to the server or '
 [disconnected /] connect
 [standalone@localhost:9990 /] 
 
-[standalone@localhost:9990 /] module add --name=com.github.thomasdarimont.keycloak.extensions.keycloak-health-checks --resources=/home/tom/dev/repos/gh/thomasdarimont/keycloak-dev/keycloak-health-checks/target/keycloak-health-checks-13.0.0.0.jar --dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-services,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,javax.api,javax.ws.rs.api,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations,org.jboss.logging,org.infinispan,org.infinispan.commons
+[standalone@localhost:9990 /] module add --name=com.github.thomasdarimont.keycloak.extensions.keycloak-health-checks --resources=/home/tom/dev/repos/gh/thomasdarimont/keycloak-dev/keycloak-health-checks/target/keycloak-health-checks-13.0.1.1.jar --dependencies=org.keycloak.keycloak-core,org.keycloak.keycloak-services,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,javax.api,javax.ws.rs.api,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-databind,com.fasterxml.jackson.core.jackson-annotations,org.jboss.logging,org.infinispan,org.infinispan.commons
 ```
 
 Alternatively, create `$KEYCLOAK_HOME/modules/com/github/thomasdarimont/keycloak/extensions/keycloak-health-checks/main/module.xml` to load extension from the local Maven repo:
@@ -31,7 +31,7 @@ Alternatively, create `$KEYCLOAK_HOME/modules/com/github/thomasdarimont/keycloak
 <module xmlns="urn:jboss:module:1.1" name="com.github.thomasdarimont.keycloak.extensions.keycloak-health-checks">
 
     <resources>
-        <artifact name="com.github.thomasdarimont.keycloak:keycloak-health-checks:13.0.0.0"/>
+        <artifact name="com.github.thomasdarimont.keycloak:keycloak-health-checks:13.0.1.1"/>
     </resources>
 
     <dependencies>

--- a/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/infinispan/InfinispanHealthIndicator.java
+++ b/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/infinispan/InfinispanHealthIndicator.java
@@ -65,9 +65,10 @@ public class InfinispanHealthIndicator extends AbstractHealthIndicator {
         switch (clusterHealth.getHealthStatus()) {
             case HEALTHY:
                 return reportUp();
-            case REBALANCING:
+            case HEALTHY_REBALANCING:
                 return reportUp();
-            case UNHEALTHY:
+            case DEGRADED:
+            case FAILED:
                 return reportDown();
             default:
                 return reportDown();


### PR DESCRIPTION
This change:
* Upgrades Keycloak dependencies from 4.8.3.Final to 13.0.0
* Upgrades Infinispan from 9.3.1.Final to 11.0.9.Final, as used by Keycloak 13.0.0
  * Updates switch statement to use [new `HealthStatus` enum values](https://github.com/infinispan/infinispan/blob/11.0.9.Final/core/src/main/java/org/infinispan/health/HealthStatus.java)
* Adds the `maven-source-plugin`