### PR TITLE
Upgrade to Keycloak 16.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.thomasdarimont.keycloak</groupId>
     <artifactId>keycloak-health-checks</artifactId>
-    <version>15.0.2.0</version>
+    <version>16.1.0.1</version>
 
     <properties>
         <!-- general settings -->
@@ -18,7 +18,7 @@
         <!-- dependency versions -->
         <lombok.version>1.18.20</lombok.version>
 
-        <keycloak.version>15.0.2</keycloak.version>
+        <keycloak.version>16.1.0</keycloak.version>
         <keycloak.versionedArtifactName>keycloak-${keycloak.version}</keycloak.versionedArtifactName>
         <infinispan.version>11.0.9.Final</infinispan.version>
     </properties>

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ A collection of health-checks for Keycloak subsystems.
 
 ## Requirements
 
-* KeyCloak 15.0.2
+* KeyCloak 16.1.0
 
 ## Build
 


### PR DESCRIPTION
Upgrades Keycloak dependencies to version `16.1.0`.