### PR TITLE
Fix memory calculation bug

### DIFF
--- a/examples/icinga2/checks/check_keycloak
+++ b/examples/icinga2/checks/check_keycloak
@@ -267,7 +267,7 @@ if ($config->check == "summary")
                         switch ($json->details->infinispan->state)
                         {
                                 case "UP":
-                                        $freeRam = (100 - (100 / $json->details->infinispan->hostInfo->totalMemoryKb * $json->details->infinispan->hostInfo->freeMemoryInKb));
+                                        $freeRam = (100 / $json->details->infinispan->hostInfo->totalMemoryKb * $json->details->infinispan->hostInfo->freeMemoryInKb);
 
                                         if ($freeRam < 20)
                                         {


### PR DESCRIPTION
`$freeRam` variable gets not a free memory but used memory and due that possible to get a warning:
```
WARNING: Infinispan free host memory is below 20% (total: 1.00 GB, free: 894.41 MB)
```

In this fix `$freeRam` calculates free memory.