### PR TITLE
Fix default database connection timeout value

### DIFF
--- a/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/database/DatabaseHealthIndicator.java
+++ b/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/database/DatabaseHealthIndicator.java
@@ -24,13 +24,13 @@ public class DatabaseHealthIndicator extends AbstractHealthIndicator {
 
     protected final String jndiName;
 
-    protected final int connectionTimeoutMillis;
+    protected final int connectionTimeout;
 
     public DatabaseHealthIndicator(KeycloakSession session, Config.Scope config) {
         super("database");
         this.jndiName = config.get("jndiName", KEYCLOAK_DATASOURCE_JNDI_NAME);
         this.healthQuery = config.get("query");
-        this.connectionTimeoutMillis = config.getInt("connectionTimeout", 1000);
+        this.connectionTimeout = config.getInt("connectionTimeout", 1);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class DatabaseHealthIndicator extends AbstractHealthIndicator {
                     }
                 }
             } else {
-                valid = connection.isValid(connectionTimeoutMillis);
+                valid = connection.isValid(connectionTimeout);
             }
             log.debugf("Connection is Valid %s", valid);
             return valid;


### PR DESCRIPTION
The extension passes value 1000 as database connection timeout by default as if it was in milliseconds, when in fact [Connection#isValid(int) uses seconds](https://docs.oracle.com/en/java/javase/18/docs/api/java.sql/java/sql/Connection.html#isValid(int)).