### PR TITLE
Make package for Keycloak v25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,6 @@ jobs:
           path: info
 
   build:
-    needs: [ release ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,10 +55,10 @@ jobs:
           echo "::set-output name=upload_url::$upload_url"
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,8 +42,17 @@ jobs:
           path: info
 
   build:
+    needs: [ release ]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: info
+      - name: Set upload_url
+        id: upload_info
+        run: |
+          upload_url=$(cat info/upload_url)
+          echo "upload_url=$upload_url" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
         id: create_tag
         run: |
           tag=$(basename "${{ github.ref }}")
-          echo "::set-output name=tag::$tag"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -52,7 +52,7 @@ jobs:
         id: upload_info
         run: |
           upload_url=$(cat info/upload_url)
-          echo "::set-output name=upload_url::$upload_url"
+          echo "upload_url=$upload_url" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -85,7 +85,7 @@ jobs:
         id: publish_info
         run: |
           release_id=$(cat info/release_id)
-          echo "::set-output name=release_id::$release_id"
+          echo "release_id=$release_id" >> $GITHUB_OUTPUT
       - uses: eregon/publish-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,14 +44,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: info
-      - name: Set upload_url
-        id: upload_info
-        run: |
-          upload_url=$(cat info/upload_url)
-          echo "upload_url=$upload_url" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.thomasdarimont.keycloak</groupId>
     <artifactId>keycloak-health-checks</artifactId>
-    <version>23.0.7.0</version>
+    <version>23.0.7.1</version>
 
     <properties>
         <!-- general settings -->

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <!-- general settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.thomasdarimont.keycloak</groupId>
     <artifactId>keycloak-health-checks</artifactId>
-    <version>20.0.0.0</version>
+    <version>23.0.7.0</version>
 
     <properties>
         <!-- general settings -->
@@ -18,7 +18,7 @@
         <!-- dependency versions -->
         <lombok.version>1.18.24</lombok.version>
 
-        <keycloak.version>20.0.0</keycloak.version>
+        <keycloak.version>23.0.7</keycloak.version>
         <keycloak.versionedArtifactName>keycloak-${keycloak.version}</keycloak.versionedArtifactName>
         <infinispan.version>13.0.10.Final</infinispan.version>
         <cdi-api.version>2.0.2</cdi-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.thomasdarimont.keycloak</groupId>
     <artifactId>keycloak-health-checks</artifactId>
-    <version>23.0.7.1</version>
+    <version>25.0.0.0</version>
 
     <properties>
         <!-- general settings -->
@@ -18,7 +18,7 @@
         <!-- dependency versions -->
         <lombok.version>1.18.24</lombok.version>
 
-        <keycloak.version>23.0.7</keycloak.version>
+        <keycloak.version>25.0.6</keycloak.version>
         <keycloak.versionedArtifactName>keycloak-${keycloak.version}</keycloak.versionedArtifactName>
         <infinispan.version>13.0.10.Final</infinispan.version>
         <cdi-api.version>2.0.2</cdi-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>10.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
             <version>${quarkus.version}</version>

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ A collection of health-checks for Keycloak subsystems.
 | 17.0.1.4                      | 17.0.1 - 18.0.1 | 17.0.1 - 18.0.1 |
 | 19.0.3.0                      | 19.0.1 - 19.0.3 | 19.0.1 - 19.0.3 |
 | 20.0.0.0                      | 20.0.0          | not supported   |
-| 23.0.7.0                      | 22.0.0 - 23.0.7 | not supported   |
+| 23.0.7.1                      | 22.0.0 - 23.0.7 | not supported   |
 
 ## Build
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ A collection of health-checks for Keycloak subsystems.
 | 17.0.1.4                      | 17.0.1 - 18.0.1 | 17.0.1 - 18.0.1 |
 | 19.0.3.0                      | 19.0.1 - 19.0.3 | 19.0.1 - 19.0.3 |
 | 20.0.0.0                      | 20.0.0          | not supported   |
+| 23.0.7.0                      | 22.0.0 - 23.0.7 | not supported   |
 
 ## Build
 

--- a/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/rest/HealthCheckResource.java
+++ b/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/rest/HealthCheckResource.java
@@ -7,12 +7,12 @@ import com.github.thomasdarimont.keycloak.healthchecker.spi.GuardedHealthIndicat
 import com.github.thomasdarimont.keycloak.healthchecker.spi.HealthIndicator;
 import org.keycloak.models.KeycloakSession;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;

--- a/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/database/DatabaseHealthIndicator.java
+++ b/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/database/DatabaseHealthIndicator.java
@@ -8,7 +8,7 @@ import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.utils.StringUtil;
 
-import javax.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.CDI;
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
 import java.sql.Connection;

--- a/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/ldap/LdapHealthIndicator.java
+++ b/src/main/java/com/github/thomasdarimont/keycloak/healthchecker/spi/ldap/LdapHealthIndicator.java
@@ -150,7 +150,7 @@ public class LdapHealthIndicator extends AbstractHealthIndicator {
 
         try (LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(ldapStorageProvider, realm)) {
             LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
-            Condition usernameCondition = conditionsBuilder.equal(UserModel.USERNAME, usernamePattern, EscapeStrategy.NON_ASCII_CHARS_ONLY);
+            Condition usernameCondition = conditionsBuilder.equal(UserModel.USERNAME, usernamePattern, EscapeStrategy.DEFAULT);
             ldapQuery.addWhereCondition(usernameCondition);
             ldapQuery.setLimit(LDAP_QUERY_RESULT_LIMIT);
 


### PR DESCRIPTION
When running the previous package version with Keycloak v25, we get a runtime error:
> ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-1) Uncaught server error: java.lang.NoClassDefFoundError: Could not initialize class com.github.thomasdarimont.keycloak.healthchecker.support.KeycloakUtil$Holder